### PR TITLE
Prevent hook error on upgrade: prometheus-metrics-job already exists

### DIFF
--- a/minio/Chart.yaml
+++ b/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 6.0.4
+version: 6.0.5
 appVersion: master
 keywords:
 - storage

--- a/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
   {{ toYaml .Values.updatePrometheusJob.annotations | indent 4 }}
 spec:
   template:


### PR DESCRIPTION
As in helm/charts#22394, the existing prometheus-metrics-job must be cleaned up otherwise helm will throw an error upon install / upgrade.

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
