### PR TITLE
[stable/minio] Don't display the ACCESS_KEY and SECRET_KEY to console

### DIFF
--- a/minio/Chart.yaml
+++ b/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 6.1.0
+version: 6.1.1
 appVersion: master
 keywords:
 - storage

--- a/minio/templates/NOTES.txt
+++ b/minio/templates/NOTES.txt
@@ -14,9 +14,11 @@ You can now access Minio server on http://localhost:9000. Follow the below steps
 
   1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
 
-  2. mc config host add {{ template "minio.fullname" . }}-local http://localhost:9000 {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+  2. Get the ACCESS_KEY=$(kubectl get secret minio -o jsonpath="{.data.accesskey}" | base64 --decode) and the SECRET_KEY=$(kubectl get secret minio -o jsonpath="{.data.secretkey}" | base64 --decode)
+	
+	3. mc alias set {{ template "minio.fullname" . }}-local http://<External-IP>:{{ .Values.service.port }} "$ACCESS_KEY" "$SECRET_KEY" --api s3v4
 
-  3. mc ls {{ template "minio.fullname" . }}-local
+  4. mc ls {{ template "minio.fullname" . }}-local
 
 Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
 {{- end }}


### PR DESCRIPTION
- This puts some logic in for the NOTES.txt so you don't display the access_key and secret_key to the console
- Fix a missing --api for the command

Co-authored-by: Paul Czarkowski username.taken@gmail.com
Signed-off-by: JJ Asghar jjasghar@gmail.com


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/minio]`)
