### PR TITLE
[stable/minio] Allow Prometheus Batch Job to use existing secret

### DIFF
--- a/minio/Chart.yaml
+++ b/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 6.2.0
+version: 6.3.0
 appVersion: master
 keywords:
 - storage

--- a/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -63,9 +63,19 @@ spec:
             - "-c"
             - mc --config-dir {{ .Values.configPathmc }} admin prometheus generate target --json --no-color -q > /workdir/mc.json
           env:
-            # mc admin prometheus generate don't really connect to remote server, TLS cert isn't required
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  key: secretkey
+            #  mc admin prometheus generate don't really connect to remote server, TLS cert isn't required
             - name: MC_HOST_target
-              value: http{{ if .Values.tls.enabled }}s{{ end }}://{{ .Values.accessKey }}:{{ .Values.secretKey }}@{{ $fullName }}:{{ .Values.service.port }}
+              value: http{{ if .Values.tls.enabled }}s{{ end }}://$(MINIO_ACCESS_KEY):$(MINIO_SECRET_KEY)@{{ $fullName }}:{{ .Values.service.port }}
           volumeMounts:
             - name: workdir
               mountPath: /workdir


### PR DESCRIPTION
* updated prometheus batch job mc container to load credentials secret to build host string
* bumped minor version

Signed-off-by: Mitchell Maler <mitchell.maler@live.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ x ] Chart Version bumped
- [ x ] Variables are documented in the README.md
- [ x ] Title of the PR starts with chart name (e.g. `[stable/minio]`)
