### PR TITLE
[stable/minio] Fix for back ticks instead of double quote in gateway's command + formatting of yaml list

### DIFF
--- a/minio/Chart.yaml
+++ b/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 7.0.4
+version: 7.0.5
 appVersion: master
 keywords:
 - storage

--- a/minio/templates/deployment.yaml
+++ b/minio/templates/deployment.yaml
@@ -70,38 +70,45 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.s3gateway.enabled }}
-          command: [ "/bin/sh",
-          "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway s3 {{ .Values.s3gateway.serviceEndpoint }} {{- template `minio.extraArgs` . }}" ]
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway s3 {{ .Values.s3gateway.serviceEndpoint }} {{- template "minio.extraArgs" . }}"
           {{- else }}
           {{- if .Values.azuregateway.enabled }}
-          command: [ "/bin/sh",
-          "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure {{- template `minio.extraArgs` . }}" ]
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway azure {{- template "minio.extraArgs" . }}"
           {{- else }}
           {{- if .Values.gcsgateway.enabled }}
-          command: [ "/bin/sh",
-          "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway gcs {{ .Values.gcsgateway.projectId }} {{- template `minio.extraArgs` . }}" ]
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway gcs {{ .Values.gcsgateway.projectId }} {{- template "minio.extraArgs" . }}"
           {{- else }}
           {{- if .Values.ossgateway.enabled }}
-          command: [ "/bin/sh",
-          "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway oss {{ .Values.ossgateway.endpointURL }} {{- template `minio.extraArgs` . }}" ]
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway oss {{ .Values.ossgateway.endpointURL }} {{- template "minio.extraArgs" . }}"
           {{- else }}
           {{- if .Values.nasgateway.enabled }}
-          command: [ "/bin/sh",
-          "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway nas {{ $bucketRoot }} {{- template `minio.extraArgs` . }}" ]
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway nas {{ $bucketRoot }} {{- template "minio.extraArgs" . }}"
           {{- else }}
           {{- if .Values.b2gateway.enabled }}
-          command: [ "/bin/sh",
-          "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway b2 {{- template `minio.extraArgs` . }}" ]
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} gateway b2 {{- template "minio.extraArgs" . }}"
           {{- else }}
-          command: [ "/bin/sh",
-          "-ce",
-          "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{ $bucketRoot }} {{- template `minio.extraArgs` . }}" ]
+          command:
+            - "/bin/sh"
+            - "-ce"
+            - "/usr/bin/docker-entrypoint.sh minio -S {{ .Values.certsPath }} server {{ $bucketRoot }} {{- template "minio.extraArgs" . }}"
           {{- end }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
* Fix for back ticks instead of double quote in gateway's command. The backticks were not valid and made `helm lint` fail.
* Formatting of list of commands in the gateway's deployment manifest to be more idiomatic of yaml.

#### Special notes for your reviewer:

* Changes were deployed and tested on Kubernetes and they work.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/minio]`)
