### PR TITLE
fix: chart variable schema statefulset

### DIFF
--- a/minio/Chart.yaml
+++ b/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 7.0.2
+version: 7.0.3
 appVersion: master
 keywords:
 - storage

--- a/minio/templates/statefulset.yaml
+++ b/minio/templates/statefulset.yaml
@@ -4,7 +4,7 @@
 {{ $drivesPerNode := .Values.drivesPerNode | int }}
 {{ $scheme := "http" }}
 {{- if .Values.tls.enabled }}
-{{ $scheme = "https" }}
+{{ $scheme := "https" }}
 {{ end }}
 {{ $mountPath := .Values.mountPath }}
 {{ $bucketRoot := or ($.Values.bucketRoot) ($.Values.mountPath) }}


### PR DESCRIPTION
#### Special notes for your reviewer:

Resolving the syntax error in line 7 of the statefulset schema

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/minio]`)
