### PR TITLE
[stable/minio] Fix post-install info

### DIFF
--- a/minio/templates/NOTES.txt
+++ b/minio/templates/NOTES.txt
@@ -14,9 +14,9 @@ You can now access Minio server on http://localhost:9000. Follow the below steps
 
   1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
 
-  2. Get the ACCESS_KEY=$(kubectl get secret minio -o jsonpath="{.data.accesskey}" | base64 --decode) and the SECRET_KEY=$(kubectl get secret minio -o jsonpath="{.data.secretkey}" | base64 --decode)
-	
-	3. mc alias set {{ template "minio.fullname" . }}-local http://<External-IP>:{{ .Values.service.port }} "$ACCESS_KEY" "$SECRET_KEY" --api s3v4
+  2. Get the ACCESS_KEY=$(kubectl get secret {{ template "minio.secretName" . }} -o jsonpath="{.data.accesskey}" | base64 --decode) and the SECRET_KEY=$(kubectl get secret {{ template "minio.secretName" . }} -o jsonpath="{.data.secretkey}" | base64 --decode)
+
+  3. mc alias set {{ template "minio.fullname" . }}-local http://localhost:{{ .Values.service.port }} "$ACCESS_KEY" "$SECRET_KEY" --api s3v4
 
   4. mc ls {{ template "minio.fullname" . }}-local
 
@@ -32,9 +32,10 @@ You can now access Minio server on http://<External-IP>:9000. Follow the below s
 
   1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide
 
-  2. mc config host add {{ template "minio.fullname" . }}-local http://<External-IP>:{{ .Values.service.port }} {{ .Values.accessKey }} {{ .Values.secretKey }} S3v4
+  2. Get the ACCESS_KEY=$(kubectl get secret {{ template "minio.secretName" . }} -o jsonpath="{.data.accesskey}" | base64 --decode) and the SECRET_KEY=$(kubectl get secret {{ template "minio.secretName" . }} -o jsonpath="{.data.secretkey}" | base64 --decode)
+  3. mc alias set {{ template "minio.fullname" . }} http://<External-IP>:{{ .Values.service.port }} "$ACCESS_KEY" "$SECRET_KEY" --api s3v4
 
-  3. mc ls {{ template "minio.fullname" . }}-local
+  4. mc ls {{ template "minio.fullname" . }}
 
 Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
 {{- end }}

--- a/minio/templates/_helpers.tpl
+++ b/minio/templates/_helpers.tpl
@@ -76,6 +76,17 @@ Return the appropriate apiVersion for ingress.
 {{- end -}}
 
 {{/*
+Determine secret name.
+*/}}
+{{- define "minio.secretName" -}}
+{{- if .Values.existingSecret -}}
+{{- .Values.existingSecret }}
+{{- else -}}
+{{- include "minio.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Determine service account name for deployment or statefulset.
 */}}
 {{- define "minio.serviceAccountName" -}}

--- a/minio/templates/deployment.yaml
+++ b/minio/templates/deployment.yaml
@@ -120,12 +120,12 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  name: {{ template "minio.secretName" . }}
                   key: accesskey
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  name: {{ template "minio.secretName" . }}
                   key: secretkey
             {{- if .Values.gcsgateway.enabled }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -156,14 +156,14 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  name: {{ template "minio.secretName" . }}
                   key: awsAccessKeyId
             {{- end }}
             {{- if .Values.s3gateway.secretKey }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  name: {{ template "minio.secretName" . }}
                   key: awsSecretAccessKey
             {{- end }}
             {{- end }}
@@ -198,6 +198,6 @@ spec:
         {{- end }}
         - name: minio-user
           secret:
-            secretName: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+            secretName: {{ template "minio.secretName" . }}
         {{- include "minio.tlsKeysVolume" . | indent 8 }}
 {{- end }}

--- a/minio/templates/post-install-create-bucket-job.yaml
+++ b/minio/templates/post-install-create-bucket-job.yaml
@@ -55,7 +55,7 @@ spec:
             - configMap:
                 name: {{ template "minio.fullname" . }}
             - secret:
-                name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                name: {{ template "minio.secretName" . }}
         {{- if .Values.tls.enabled }}
         - name: cert-secret-volume-mc
           secret:

--- a/minio/templates/post-install-prometheus-metrics-job.yaml
+++ b/minio/templates/post-install-prometheus-metrics-job.yaml
@@ -70,12 +70,12 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  name: {{ template "minio.secretName" . }}
                   key: accesskey
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  name: {{ template "minio.secretName" . }}
                   key: secretkey
             #  mc admin prometheus generate don't really connect to remote server, TLS cert isn't required
             - name: MC_HOST_target

--- a/minio/templates/secrets.yaml
+++ b/minio/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "minio.fullname" . }}
+  name: {{ template "minio.secretName" . }}
   labels:
     app: {{ template "minio.name" . }}
     chart: {{ template "minio.chart" . }}

--- a/minio/templates/statefulset.yaml
+++ b/minio/templates/statefulset.yaml
@@ -112,12 +112,12 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  name: {{ template "minio.secretName" . }}
                   key: accesskey
             - name: MINIO_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+                  name: {{ template "minio.secretName" . }}
                   key: secretkey
             {{- range $key, $val := .Values.environment }}
             - name: {{ $key }}
@@ -141,7 +141,7 @@ spec:
       volumes:
         - name: minio-user
           secret:
-            secretName: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
+            secretName: {{ template "minio.secretName" . }}
         {{- include "minio.tlsKeysVolume" . | indent 8 }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:


### PR DESCRIPTION
- Move secret name chooser function to helpers.
- Show valid secret name.
- Remove "local" suffix in mc config name in case "LoadBalancer" service type.
- Replace deprecated "config" command with "alias".
- Do not display access and secret keys.
- Other misc edits.

Signed-off-by: Arano-kai <captcha.is(dot)evil(meov)gmail.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped (additional push after approvement)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/minio]`)
