### PR TITLE
[stable/minio] Fix keys usage and etcd section behaviour

### DIFF
--- a/minio/templates/deployment.yaml
+++ b/minio/templates/deployment.yaml
@@ -127,14 +127,13 @@ spec:
                 secretKeyRef:
                   name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
                   key: secretkey
-            {{- if .Values.gcsgateway.enabled }}
+            {{- if and .Values.gcsgateway.enabled .Values.gcsgateway.gcsKeyJson }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/etc/credentials/gcs_key.json"
             {{- end }}
             {{- if .Values.etcd.endpoints }}
             - name: MINIO_ETCD_ENDPOINTS
               value: {{ join "," .Values.etcd.endpoints | quote }}
-            {{- end }}
             {{- if .Values.etcd.clientCert }}
             - name: MINIO_ETCD_CLIENT_CERT
               value: "/etc/credentials/etcd_client_cert.pem"
@@ -151,15 +150,16 @@ spec:
             - name: MINIO_ETCD_COREDNS_PATH
               value: {{ .Values.etcd.corednsPathPrefix }}
             {{- end }}
+            {{- end }}
             {{- if .Values.s3gateway.enabled -}}
-            {{- if .Values.s3gateway.accessKey }}
+            {{- if or .Values.s3gateway.accessKey .Values.existingSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "minio.fullname" . }}{{ end }}
                   key: awsAccessKeyId
             {{- end }}
-            {{- if .Values.s3gateway.secretKey }}
+            {{- if and .Values.s3gateway.secretKey .Values.existingSecret }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/minio/templates/secrets.yaml
+++ b/minio/templates/secrets.yaml
@@ -12,7 +12,7 @@ type: Opaque
 data:
   accesskey: {{ if .Values.accessKey }}{{ .Values.accessKey | b64enc | quote }}{{ else }}{{ randAlphaNum 20 | b64enc | quote }}{{ end }}
   secretkey: {{ if .Values.secretKey }}{{ .Values.secretKey | b64enc | quote }}{{ else }}{{ randAlphaNum 40 | b64enc | quote }}{{ end }}
-{{- if .Values.gcsgateway.enabled }}
+{{- if and .Values.gcsgateway.enabled .Values.gcsgateway.gcsKeyJson }}
   gcs_key.json: {{ .Values.gcsgateway.gcsKeyJson | b64enc }}
 {{- end }}
 {{- if .Values.s3gateway.enabled -}}

--- a/minio/values.yaml
+++ b/minio/values.yaml
@@ -320,6 +320,7 @@ metrics:
     # scrapeTimeout: 10s
 
 ## ETCD settings: https://github.com/minio/minio/blob/master/docs/sts/etcd.md
+## Define endpoints to enable this section.
 etcd:
   endpoints: []
   pathPrefix: ""


### PR DESCRIPTION
- Use s3gateway.accessKey and .s3gateway.secretKey from existingSecret.
- Enable etcd related env if endpoints defined.
- Check gcsgateway.gcsKeyJson before inclusion.

Signed-off-by: Arano-kai <captcha.is(dot)evil(meov)gmail.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped (additional push after approvement)
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/minio]`)
