### PR TITLE
[stable/minio] fix issue #37 : wrong apiVersion returned for kubernetes > 1.16.0

### DIFF
--- a/minio/Chart.yaml
+++ b/minio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: 8.0.0
+version: 8.0.1
 appVersion: master
 keywords:
 - storage

--- a/minio/templates/_helpers.tpl
+++ b/minio/templates/_helpers.tpl
@@ -35,9 +35,9 @@ Create chart name and version as used by the chart label.
 Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "minio.networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
-{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.Version -}}
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
@@ -46,10 +46,10 @@ Return the appropriate apiVersion for networkpolicy.
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "minio.deployment.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "apps/v1beta2" -}}
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
 {{- print "apps/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta2/Deployment" -}}
+{{- print "apps/v1beta2" -}}
 {{- end -}}
 {{- end -}}
 
@@ -57,10 +57,10 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "minio.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.17-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "apps/v1beta2" -}}
-{{- else -}}
+{{- if .Capabilities.APIVersions.Has "apps/v1/StatefulSet" -}}
 {{- print "apps/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "apps/v1beta2/StatefulSet" -}}
+{{- print "apps/v1beta2" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Due to calls to deprecated .Capabilities.KubeVersion.GitVersion
Replaced by .Capabilities.APIVersions.Has and .Capabilities.KubeVersion.Version

#### Special notes for your reviewer:

As helm3 doesn't check apiVersions on an helm template, either the --validate flag is required or helm upgrade --dry-run

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/minio]`)
