### PR TITLE
Fix description of the example helm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ You can specify each parameter using the `--set key=value[,key=value]` argument 
 $ helm install --name my-release --set persistence.size=1Ti minio/minio
 ```
 
-The above command deploys MinIO server with a 100Gi backing persistent volume.
+The above command deploys MinIO server with a 1Ti backing persistent volume.
 
 Alternately, you can provide a YAML file that specifies parameter values while installing the chart. For example,
 


### PR DESCRIPTION
Fix description of the example helm command (100Gi -> 1Ti)

Signed-off-by: Sergey Shevelev <shevelevs@gmail.com>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/minio]`)
