### PR TITLE
default the apiVersion of the StatefulSet to apps/v1beta2

### DIFF
--- a/minio/templates/statefulset.yaml
+++ b/minio/templates/statefulset.yaml
@@ -33,7 +33,7 @@ spec:
     app: {{ template "minio.name" . }}
     release: {{ .Release.Name }}
 ---
-apiVersion: {{ template "minio.statefulset.apiVersion" . }}
+apiVersion: {{ template "minio.statefulset.apiVersion" . | default "apps/v1beta2" }}
 kind: StatefulSet
 metadata:
   name: {{ template "minio.fullname" . }}


### PR DESCRIPTION
Hi,
The following error is observed from `kubeval` during manifest validation:

```
manifest.yaml: Missing 'apiVersion' value
```

The issue seems to have been introduced in https://github.com/minio/charts/pull/49.