### PR TITLE
fix: add environment default values and exmaple

### DIFF
--- a/minio/values.yaml
+++ b/minio/values.yaml
@@ -303,8 +303,10 @@ nasgateway:
 
 ## Use this field to add environment variables relevant to Minio server. These fields will be passed on to Minio container(s)
 ## when Chart is deployed
-environment:
+environment: {}
   ## Please refer for comprehensive list https://docs.minio.io/docs/minio-server-configuration-guide.html
+  ## MINIO_DOMAIN: "chart-example.local"
+  ## MINIO_BROWSER: "off"
 
 networkPolicy:
   enabled: false


### PR DESCRIPTION
This fix is to avoid the warning when adding `environment`

Here is the warning:
`warning: skipped value for environment: Not a table.`

