### PR TITLE
[stable/minio] Remove minio SCC priority value

### DIFF
--- a/minio/templates/securitycontextconstraints.yaml
+++ b/minio/templates/securitycontextconstraints.yaml
@@ -8,7 +8,6 @@ metadata:
     chart: {{ template "minio.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-priority: 10
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false


### PR DESCRIPTION
Fixes #99.

I verified that with this change implemented:
* Minio Deployment uses Minio SCC
* All other workload stops using Minio SCC

#### Special notes for your reviewer:

Please bump the version.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/minio]`)
