### PR TITLE
[minio] Add support for non-public Azure Storage in Azure gateway mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ The following table lists the configurable parameters of the MinIO chart and the
 | `s3gateway.secretKey`                            | Secret key of S3 compatible service                                                                                                     | `""`                             |
 | `azuregateway.enabled`                           | Use MinIO as an [azure gateway](https://docs.minio.io/docs/minio-gateway-for-azure)                                                     | `false`                          |
 | `azuregateway.replicas`                          | Number of azure gateway instances to run in parallel                                                                                    | `4`                              |
+| `azuregateway.storageAccount`                    | Storage account name to access Azure Storage                                                                                            | `""`                             |
+| `azuregateway.storageKey`                        | Secret storage account key to access Azure Storage                                                                                      | `""`                             |
 | `gcsgateway.enabled`                             | Use MinIO as a [Google Cloud Storage gateway](https://docs.minio.io/docs/minio-gateway-for-gcs)                                         | `false`                          |
 | `gcsgateway.gcsKeyJson`                          | credential json file of service account key                                                                                             | `""`                             |
 | `gcsgateway.projectId`                           | Google cloud project id                                                                                                                 | `""`                             |
@@ -362,15 +364,17 @@ $ helm install --set existingSecret=my-minio-secret minio/minio
 
 The following fields are expected in the secret:
 
-| .data.<key> in Secret      | Corresponding variable  | Description                                                                       |
-|:---------------------------|:------------------------|:----------------------------------------------------------------------------------|
-| `accesskey`                | `accessKey`             | Access key ID. Mandatory.                                                         |
-| `secretkey`                | `secretKey`             | Secret key. Mandatory.                                                            |
-| `gcs_key.json`             | `gcsgateway.gcsKeyJson` | GCS key if you are using the GCS gateway feature. Optional                        |
-| `awsAccessKeyId`           | `s3gateway.accessKey`   | S3 access key if you are using the S3 gateway feature. Optional                   |
-| `awsSecretAccessKey`       | `s3gateway.secretKey`   | S3 secret key if you are using the S3 gateway feature. Optional                   |
-| `etcd_client_cert.pem`     | `etcd.clientCert`       | Certificate for SSL/TLS connections to etcd. Optional                             |
-| `etcd_client_cert_key.pem` | `etcd.clientCertKey`    | Corresponding key for certificate above. Mandatory when etcd certificate defined. |
+| .data.<key> in Secret      | Corresponding variable          | Description                                                                           |
+|:---------------------------|:--------------------------------|:--------------------------------------------------------------------------------------|
+| `accesskey`                | `accessKey`                     | Access key ID. Mandatory.                                                             |
+| `secretkey`                | `secretKey`                     | Secret key. Mandatory.                                                                |
+| `gcs_key.json`             | `gcsgateway.gcsKeyJson`         | GCS key if you are using the GCS gateway feature. Optional                            |
+| `awsAccessKeyId`           | `s3gateway.accessKey`           | S3 access key if you are using the S3 gateway feature. Optional                       |
+| `awsSecretAccessKey`       | `s3gateway.secretKey`           | S3 secret key if you are using the S3 gateway feature. Optional                       |
+| `azureStorageAccount`      | `azuregateway.storageAccount`   | Azure Storage account name if you are using the Azure gateway feature. Optional       |
+| `azureStorageKey`          | `azuregateway.storageKey`       | Azure Storage account secret key if you are using the Azure gateway feature. Optional |
+| `etcd_client_cert.pem`     | `etcd.clientCert`               | Certificate for SSL/TLS connections to etcd. Optional                                 |
+| `etcd_client_cert_key.pem` | `etcd.clientCertKey`            | Corresponding key for certificate above. Mandatory when etcd certificate defined.     |
 
 All corresponding variables will be ignored in values file.
 

--- a/minio/templates/deployment.yaml
+++ b/minio/templates/deployment.yaml
@@ -174,6 +174,23 @@ spec:
                   key: awsSecretAccessKey
             {{- end }}
             {{- end }}
+
+            {{- if .Values.azuregateway.enabled -}}
+            {{- if or .Values.azuregateway.storageAccount .Values.existingSecret }}
+            - name: AZURE_STORAGE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: azureStorageAccount
+            {{- end }}
+            {{- if or .Values.azuregateway.storageKey .Values.existingSecret }}
+            - name: AZURE_STORAGE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "minio.secretName" . }}
+                  key: azureStorageKey
+            {{- end }}
+            {{- end }}
             {{- range $key, $val := .Values.environment }}
             - name: {{ $key }}
               value: {{ $val | quote }}

--- a/minio/templates/secrets.yaml
+++ b/minio/templates/secrets.yaml
@@ -23,6 +23,14 @@ data:
   awsSecretAccessKey: {{ .Values.s3gateway.secretKey | toString | b64enc | quote }}
 {{- end }}
 {{- end }}
+{{- if .Values.azuregateway.enabled -}}
+{{- if .Values.azuregateway.storageAccount }}
+  azureStorageAccount: {{ .Values.azuregateway.storageAccount | toString | b64enc | quote }}
+{{- end }}
+{{- if .Values.azuregateway.storageKey }}
+  azureStorageKey: {{ .Values.azuregateway.storageKey | toString | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.etcd.clientCert }}
   etcd_client_cert.pem: {{ .Values.etcd.clientCert | toString | b64enc | quote }}
 {{- end }}

--- a/minio/values.yaml
+++ b/minio/values.yaml
@@ -75,15 +75,17 @@ mountPath: "/export"
 
 ## Use existing Secret that store following variables:
 ##
-## | Chart var             | .data.<key> in Secret    |
-## |:----------------------|:-------------------------|
-## | accessKey             | accesskey                |
-## | secretKey             | secretkey                |
-## | gcsgateway.gcsKeyJson | gcs_key.json             |
-## | s3gateway.accessKey   | awsAccessKeyId           |
-## | s3gateway.secretKey   | awsSecretAccessKey       |
-## | etcd.clientCert       | etcd_client_cert.pem     |
-## | etcd.clientCertKey    | etcd_client_cert_key.pem |
+## | Chart var                   | .data.<key> in Secret    |
+## |:----------------------------|:-------------------------|
+## | accessKey                   | accesskey                |
+## | secretKey                   | secretkey                |
+## | gcsgateway.gcsKeyJson       | gcs_key.json             |
+## | s3gateway.accessKey         | awsAccessKeyId           |
+## | s3gateway.secretKey         | awsSecretAccessKey       |
+## | azuregateway.storageAccount | azureStorageAccount      |
+## | azuregateway.storageKey     | azureStorageKey          |
+## | etcd.clientCert             | etcd_client_cert.pem     |
+## | etcd.clientCertKey          | etcd_client_cert_key.pem |
 ##
 ## All mentioned variables will be ignored in values file.
 ## .data.accesskey and .data.secretkey are mandatory,
@@ -283,6 +285,8 @@ azuregateway:
   enabled: false
   # Number of parallel instances
   replicas: 4
+  storageAccount: ""
+  storageKey: ""
 
 ## Use minio as GCS (Google Cloud Storage) gateway, you should disable data persistence so no volume claim are created.
 ## https://docs.minio.io/docs/minio-gateway-for-gcs


### PR DESCRIPTION
#### Special notes for your reviewer:

This PR adds support for non-public Azure Storage in Azure gateway mode according to the official instruction: https://docs.min.io/docs/minio-gateway-for-azure.html (section `Use custom access/secret keys`)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/minio]`)
